### PR TITLE
Update CNSRegistry.sol

### DIFF
--- a/contracts/CNSRegistry.sol
+++ b/contracts/CNSRegistry.sol
@@ -2,225 +2,344 @@
 
 pragma solidity ^0.8.0;
 
-// We first import some OpenZeppelin Contracts.
+
+
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/utils/Base64.sol";
-import "hardhat/console.sol"; // to allow console logging for easier debuging
+import "hardhat/console.sol";
 
-// We inherit the contracts we imported. This means we'll have access
-// to the inherited contract's methods. So 'is' keyword gives it power
-// to inherit other contracts
+
+
 contract CNSRegistry is ERC721, ERC721Enumerable, ERC721URIStorage {
-    // this allows us to help us keep track of tokenIds.
-    using Counters for Counters.Counter;
-    Counters.Counter private _tokenIds;
-    struct CName {
-        address owner;
-        bool listed;
-        uint256 price;
-        uint256 sold;
-        address[] favorites;
-    }
-    mapping(uint256 => CName) public CNames; //to keep track of the structs
-    mapping(string => address) public registeredNames; //to  map the registered names to the owners
-    mapping(uint256 => address) public favorited; // to keep track of those that have already liked an nft
-    mapping(address => string) public imageToAddress; // to map the address/users to the avicons
-    event Registered(address indexed who, string name); // emit this upon successfull registration
 
-    // This is our SVG code. All we need to change is the name that's displayed. Everything else stays the same.
-    // So, we make a baseSvg variable here that all our NFTs can use.
-    // We split the SVG at the part where it asks for the background color.
+    using Counters for Counters.Counter;
+
+    Counters.Counter private _tokenIds;
+
+
+
+    struct CName {
+
+        bool listed;
+
+        uint256 price;
+
+        uint256 sold;
+
+        address[] favorites;
+
+    }
+
+
+
+    mapping(uint256 => CName) public CNames;
+
+    mapping(string => address) public registeredNames;
+
+    mapping(uint256 => address[]) public favorited;
+
+    mapping(address => string) public imageToAddress;
+
+
+
+    event Registered(address indexed who, string name);
+
+
+
     string svgPartOne =
+
         "<svg xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMin meet' viewBox='0 0 350 350'><style>.base { fill: white; font-family: serif; font-size: 24px; }</style><rect width='100%' height='100%' fill='";
+
     string svgPartTwo =
+
         "'/><text x='50%' y='50%' class='base' dominant-baseline='middle' text-anchor='middle'>";
 
-    // initialising the name and it's symbol of the ERC721 contract.
+
+
     constructor() ERC721("ENSRegistry", "ENSR") {}
 
-    // A function used to reserve the CNS names
+
+
     function reserveName(string memory _name, string memory _bgColor) public {
-        // query to see if the name is still available
+
         require(registeredNames[_name] == address(0), "Name Already taken");
-        // if yes, we reconstruct the svg to  include the name and bg color
+
         string memory finalSvg = string(
+
             abi.encodePacked(
+
                 svgPartOne,
+
                 _bgColor,
+
                 svgPartTwo,
+
                 _name,
+
                 "</text></svg>"
+
             )
-        );
-        //@dev to autofill the .celo extention to the input name
-        string memory name = string(abi.encodePacked(_name, ".celo"));
-        // console.log(name)
-        // Get all the JSON metadata in place and base64 encode it.
-        string memory json = Base64.encode( // this whole block encodes our json data into base64
-            bytes(
-                string(
-                    abi.encodePacked(
-                        '{"name": "', // here we dynmaically add the name to it
-                        // We set the title of our NFT as the generated word.
-                        name,
-                        '", "description": "Your Unique identity on the celo Blockchain.", "image": "data:image/svg+xml;base64,',
-                        // We add data:image/svg+xml;base64 and then append our base64 encode our svg.
-                        Base64.encode(bytes(finalSvg)),
-                        '"}'
-                    )
-                )
-            )
+
         );
 
-        // Just like before, we prepend data:application/json;base64, to our data.
-        string memory finalTokenUri = string(
-            abi.encodePacked("data:application/json;base64,", json) // so here we put it all together
-        );
-        /** 
-        console.log(
-            string(
-                abi.encodePacked( // passed it in as a parameter
-                    "https://nftpreview.0xdev.codes/?code=", // with this we can do a quick preview of the image and the contents of the json without deploying it again and again on the opensea testnet
-                    finalTokenUri
+        string memory name = string(abi.encodePacked(_name, ".celo"));
+
+        string memory json = Base64.encode(
+
+            bytes(
+
+                string(
+
+                    abi.encodePacked(
+
+                        '{"name": "',
+
+                        name,
+
+                        '", "description": "Your Unique identity on the celo Blockchain.", "image": "data:image/svg+xml;base64,',
+
+                        Base64.encode(bytes(finalSvg)),
+
+                        '"}'
+
+                    )
+
                 )
+
             )
+
         );
-        */
-        // Actually mint the NFT to the sender using msg.sender.
+
+        string memory finalTokenUri = string(
+
+            abi.encodePacked("data:application/json;base64,", json)
+
+        );
+
         uint256 newTokenId = _tokenIds.current();
+
         _safeMint(msg.sender, newTokenId);
 
-        //  Updated our URI to be consistent with our Json files
         _setTokenURI(newTokenId, finalTokenUri);
-        // updated the struct
+
         CName storage newCName = CNames[newTokenId];
-        newCName.owner = msg.sender;
+
         newCName.listed = false;
+
         newCName.price = 0;
+
         newCName.sold = 0;
+
         registeredNames[_name] = msg.sender;
-        // Increment the counter for when the next NFT is minted.
+
         _tokenIds.increment();
-        // emit the event
+
         emit Registered(msg.sender, _name);
+
     }
 
-    // function to list the nfts
+
+
     function sell(uint256 _tokenId, uint256 _price) public {
-        require(
-            CNames[_tokenId].owner == msg.sender,
-            "Only NFT owner can list Item"
-        );
+
+        require(ownerOf(_tokenId) == msg.sender, "Only NFT owner can list Item");
+
         require(_price > 0, "price should be greater than zero");
-        // update the struct
+
         CName storage editCName = CNames[_tokenId];
+
         editCName.listed = true;
+
         editCName.price = _price;
+
     }
 
-    // function to buy an nft and transfer ownership
+
+
     function buyNFT(uint256 _tokenId) public payable {
-        require(
-            CNames[_tokenId].owner != msg.sender,
-            "Owner can not buy own item"
-        );
+
+        require(ownerOf(_tokenId) != msg.sender, "Owner can not buy own item");
+
         require(CNames[_tokenId].listed == true, "nft not listed");
+
         require(
+
             CNames[_tokenId].price <= msg.value,
+
             "insufficient funds to purchase item"
+
         );
 
-        (bool success, ) = payable(CNames[_tokenId].owner).call{
-            value: msg.value
-        }(""); // pay for the nft
-        if (success) _transfer(CNames[_tokenId].owner, msg.sender, _tokenId); // transfer nft
-        // update the struct
+        (bool success, ) = payable(ownerOf(_tokenId)).call{value: msg.value}("");
+
+        if (success) _transfer(ownerOf(_tokenId), msg.sender, _tokenId);
+
         CName storage buyCName = CNames[_tokenId];
+
         buyCName.owner = msg.sender;
+
         buyCName.listed = false;
+
         buyCName.sold += 1;
+
     }
 
-    // function to fetch the nfts
+
+
     function getNft(uint256 _tokenId)
+
         public
+
         view
+
         returns (
+
             address,
+
             bool,
+
             uint256,
+
             uint256,
+
             address[] memory
+
         )
+
     {
+
         CName storage rCName = CNames[_tokenId];
+
         return (
-            rCName.owner,
+
+            ownerOf(_tokenId),
+
             rCName.listed,
+
             rCName.price,
+
             rCName.sold,
+
             rCName.favorites
+
         );
+
     }
 
-    // function to like the nfts
+
+
     function likeNft(uint256 _tokenId) public {
-        require(favorited[_tokenId] != msg.sender, "nft already favorited");
+
+        require(!isFavorited(_tokenId, msg.sender), "nft already favorited");
+
         CName storage likeCName = CNames[_tokenId];
+
         likeCName.favorites.push(msg.sender);
-        favorited[_tokenId] = msg.sender;
+
+        favorited[_tokenId].push(msg.sender);
+
     }
 
-    // function to update the struct with the image of the users
+
+
+    function isFavorited(uint256 _tokenId, address _address) public view returns (bool) {
+
+        address[] memory favorites = favorited[_tokenId];
+
+        for(uint i = 0; i < favorites.length; i++) {
+
+            if(favorites[i] == _address) {
+
+                return true;
+
+            }
+
+        }
+
+        return false;
+
+    }
+
+
+
     function setAddressAvicon(string memory _imageUri) public {
+
         imageToAddress[msg.sender] = _imageUri;
+
     }
 
-    // function to query the mapping for the users' imageUri/avicon
+
+
     function getAddressAvicon(address _address)
+
         public
+
         view
+
         returns (string memory)
+
     {
+
         string memory _imageUri = imageToAddress[_address];
+
         return _imageUri;
+
     }
 
-    // The following functions are overrides required by Solidity.
+
 
     function _beforeTokenTransfer(
+
         address from,
+
         address to,
+
         uint256 tokenId
+
     ) internal override(ERC721, ERC721Enumerable) {
+
         super._beforeTokenTransfer(from, to, tokenId);
+
     }
 
-    function _burn(uint256 tokenId)
-        internal
-        override(ERC721, ERC721URIStorage)
-    {
-        super._burn(tokenId);
-    }
+
 
     function tokenURI(uint256 tokenId)
+
         public
+
         view
+
         override(ERC721, ERC721URIStorage)
+
         returns (string memory)
+
     {
+
         return super.tokenURI(tokenId);
+
     }
 
+
+
     function supportsInterface(bytes4 interfaceId)
+
         public
+
         view
+
         override(ERC721, ERC721Enumerable)
+
         returns (bool)
+
     {
+
         return super.supportsInterface(interfaceId);
+
     }
+
 }
+


### PR DESCRIPTION
#### Potential Improvements and Fixes

1. **Redundant Data Storage**: The `CName` struct and the `CNames` mapping seem to duplicate some of the functionality already provided by the ERC721 standard. For instance, the `owner` field in the `CName` struct is unnecessary because the ERC721 standard already provides a way to look up the owner of a token. You can use the `ownerOf` function from the ERC721 standard to get the owner of a token.

2. **Lack of Access Control**: The `setAddressAvicon` function allows any address to set an image URI for any other address. This could be a security issue if you only want the owner of an address to be able to set their own image URI. Consider adding a `require` statement to ensure that `msg.sender` is the same as `_address`.

3. **Inefficient Storage**: The `favorited` mapping stores the address of the user who favorited a token. If a token is favorited by multiple users, this mapping will only store the address of the last user. Consider changing this to a mapping from token ID to an array of addresses, similar to the `favorites` field in the `CName` struct.

4. **Missing Functionality**: The `likeNft` function allows a user to favorite an NFT, but there is no way to unfavorite an NFT. Consider adding this functionality.

5. **Token Burning**: The `_burn` function is overridden but does not include any additional functionality. If you do not need to add any functionality to this function, you can remove the override.

6. **Code Comments**: While the code is generally well-commented, some functions (like `getNft` and `likeNft`) could benefit from additional comments explaining what they do.